### PR TITLE
Add docs to front page README and to front page of crate docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,26 @@ lighthouse = "0.2"
 And then in your application:
 
 ```rust
+use std::net::{IpAddr, Ipv4Addr};
+use lighthouse::bridge::Bridge;
 # Acquire your IP address and substitute here
-let ip_addr = std::net::Ipv4Addr::new(192.168.1.10);
+let ip_addr = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10));
 # Get an API token from your bridge, requires proof of physical access
-let bridge_token = String::new("my-example-token");
-let bridge = Bridge::new(ip_addr, bridge_token).unwrap();
+let bridge_token = String::from("my-example-token");
+let mut bridge = Bridge::new(ip_addr, bridge_token).unwrap();
 let lights = bridge.scan();
 ```
+
+If you haven't set up a user token or discovered your bridge yet, you can do so with the interactive `try_register` function:
+
+```rust
+use lighthouse::*;
+// Discovers the bridge's IP and registers a user token
+// This requires physical access to the Bridge!
+let b = bridge::Bridge::try_register(true);
+```
+
+See the `./examples/` directory for more examples.
 
 **NOTE:**
 The features for color conversion and serialisation to and from files are now behind 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,20 +8,21 @@
 //!
 //! ## Constucting the Bridge client and finding your lights
 //!
-//! ```rust
+//! ```no_run
+//! use std::net::{IpAddr, Ipv4Addr};
 //! use lighthouse::bridge::Bridge;
-//! let ip_addr = std::net::Ipv4Addr::new(192.168.1.10);
-//! let bridge_token = String::new("my-example-token");
-//! let bridge = Bridge::new(ip_addr, bridge_token).unwrap();
+//! let ip_addr = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10));
+//! let bridge_token = String::from("my-example-token");
+//! let mut bridge = Bridge::new(ip_addr, bridge_token).unwrap();
 //! let lights = bridge.scan();
 //! ```
 //!
 //! ## Controlling individual lights
 //!
-//! ```rust
+//! ```no_run
 //! use lighthouse::state;
 //! use lighthouse::bridge::Bridge;
-//! let bridge = Bridge::new("192.168.1.10".parse(), "token").unwrap();
+//! let mut bridge = Bridge::new("192.168.1.10".parse().unwrap(), "token".to_string()).unwrap();
 //! bridge.state_to(1, state!(on: true, bri: 128));
 //! ```
 


### PR DESCRIPTION
This adds some basic descriptions and example usages to the README and to the documentation generated by rustdoc.

Examples in the docs also contribute a little to unit testing.