### PR TITLE
Make persist feature flag optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,16 @@ serde_json = "1.0.56"
 # Optional dependencies
 palette = {version ="0.5.0" , optional = true}
 
+[[example]]
+name = "registration"
+path = "examples/registration.rs"
+
+[[example]]
+name = "basic-cli"
+path = "examples/basic_cli.rs"
+
+[[example]]
+name = "save_bridge"
+path = "examples/save_bridge.rs"
+required-features = ["persist"]
+

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -109,6 +109,7 @@ fn test_from_state() {
 }
 
 #[test]
+#[cfg(feature = "persist")]
 fn test_bridge_serialization() {
     use lighthouse::*;
 


### PR DESCRIPTION
In this PR, I've added a the persist flag to the test case which uses the persist features. This means if you just run `cargo test` this test case will not be run, however the tests will now build. `cargo test --features "persist"` will continue to operate as before.

I've also enumerated the examples in `Cargo.toml` and added the `required-features` tag to `save_bridge` so that it does not cause an error running `cargo build` or `cargo test`.